### PR TITLE
update config open for python3

### DIFF
--- a/csirtgsdk/utils.py
+++ b/csirtgsdk/utils.py
@@ -3,7 +3,7 @@ import yaml
 import os
 import sys
 from csirtgsdk.constants import REMOTE, LOG_FORMAT
-
+from io import open
 
 def read_config(args):
     """
@@ -14,7 +14,7 @@ def read_config(args):
     """
     options = {}
     if os.path.isfile(args.config):
-        f = file(args.config)
+        f = open(args.config, 'rt')
         config = yaml.load(f)
         f.close()
         if not config:


### PR DESCRIPTION
Support python2 and python3 opening the config file (.csirtg.yml)

fixes #62 

ref:
from io import open
http://python-future.org/compatible_idioms.html#file